### PR TITLE
Investigate frontend backend payload type mismatches

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.490.0",
     "@aws-sdk/s3-request-presigner": "^3.490.0",
-    "phonoglyph-types": "^0.1.3",
+    "phonoglyph-types": "workspace:*",
     "@supabase/supabase-js": "^2.50.2",
     "@trpc/server": "10.45.2",
     "@types/fluent-ffmpeg": "^2.1.27",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.1",
     "@hookform/resolvers": "^5.1.1",
-    "phonoglyph-types": "^0.1.3",
+    "phonoglyph-types": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@phonoglyph/types",
+  "name": "phonoglyph-types",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "main": "index.ts",
   "types": "index.ts",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,13 @@ importers:
         specifier: ^8.11.3
         version: 8.16.3
       phonoglyph-types:
+<<<<<<< HEAD
         specifier: ^0.1.3
         version: 0.1.3
+=======
+        specifier: workspace:*
+        version: link:../../packages/types
+>>>>>>> cursor/investigate-frontend-backend-payload-type-mismatches-5a29
       sharp:
         specifier: ^0.32.6
         version: 0.32.6
@@ -218,8 +223,13 @@ importers:
         specifier: ^14.2.30
         version: 14.2.30(@babel/core@7.27.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       phonoglyph-types:
+<<<<<<< HEAD
         specifier: ^0.1.3
         version: 0.1.3
+=======
+        specifier: workspace:*
+        version: link:../../packages/types
+>>>>>>> cursor/investigate-frontend-backend-payload-type-mismatches-5a29
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
Rename shared types package from `@phonoglyph/types` to `phonoglyph-types` and update dependencies.

The previous commit incorrectly used a scoped name for a public package, causing issues with publication. This PR corrects the package name and updates all references to ensure proper dependency resolution.